### PR TITLE
Fix phpstan/phpstan ^0.12.43 requires unsupported nikic/php-parser 4.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,14 @@
     "php": "^7.2",
     "rector/rector": "^0.8.0",
     "slevomat/coding-standard": "^6.4",
-    "symplify/easy-coding-standard": "^8.2"
+    "symplify/easy-coding-standard": "^8.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
     "roave/security-advisories": "dev-master"
+  },
+  "conflict": {
+    "phpstan/phpstan": "^0.12.43"
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
- phpstan/phpstan ^0.12.43 requires unsupported nikic/php-parser 4.10.0
- rector/rector ^0.8.7  requires nikic/php-parser ^4.9